### PR TITLE
Add ChernivtsiJS 2020

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 | Конференция | Место | Дата | Дедлайн | CFP |
 | ---------- | -------- | ---- | ------------------- | ------------------------ |
 | [UWDC](https://uwdc.ru/#uwdc2020) | Челябинск | июнь, 2020 | … | [RU](mailto://ya@sitko.ru) |
+| [ChernivtsiJS 2020](https://chernivtsi.js.org) | Черновцы, Украина | 20 июня, 2020 | … | [UK, EN, RU](https://forms.gle/vvY1PiCqLKfK5fEK7) |
 
 ### Сентябрь
 


### PR DESCRIPTION
Why UK, not UA?

UK is an official Ukrainian language's ISO code. Ref: https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes

I directly mentioned "Черновцы, Украина" to avoid any confusion regarding the country.